### PR TITLE
Make post images friendly to slower connections

### DIFF
--- a/helpers/html-images.js
+++ b/helpers/html-images.js
@@ -1,0 +1,43 @@
+import { config } from "../_config.js";
+import { getMedia } from "../data/post.js";
+
+function prepareImagesForLoading({ html, DOMParser }) {
+  try {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+
+    const images = doc.querySelectorAll("img");
+
+    for (const image of images) {
+
+      // Add height attribute for image if it’s missing and we have the data
+      const imageData = getMedia(image.getAttribute("src").replace(config.data.host, ""));
+      if (
+        imageData?.height &&
+        imageData?.width &&
+        image.hasAttribute("width") &&
+        image.hasAttribute("height") === false
+      ) {
+        const imageRenderedWidth = Number(image.getAttribute("width"));
+        const imageRenderedHeight = (imageData.height / imageData.width) * imageRenderedWidth;
+        image.setAttribute("height", imageRenderedHeight);
+      }
+
+      // Load image lazily if it has width and height attributes
+      if (image.hasAttribute("width") && image.hasAttribute("height")) {
+        image.setAttribute("loading", "lazy");
+      }
+
+    }
+
+    return doc.documentElement.outerHTML;
+
+  } catch(e) {
+    console.log(e);
+    console.log({html});
+    return html;
+  }
+}
+
+export {
+  prepareImagesForLoading
+};

--- a/pages/default.js
+++ b/pages/default.js
@@ -5,6 +5,8 @@ const    html = htm.bind(createElement);
 
 import { normalizeURL }   from "../helpers/url.js";
 
+import { prepareImagesForLoading } from "../helpers/html-images.js";
+
 import { PageHeader }     from "../components/page-header.js";
 
 
@@ -16,7 +18,7 @@ function DefaultPage({ page, DOMParser }) {
 
       <div class="body"
         dangerouslySetInnerHTML=${
-          { __html: page.content.rendered }
+          { __html: prepareImagesForLoading({ html: page.content.rendered, DOMParser }) }
         }>
       </div>
 

--- a/pages/post.js
+++ b/pages/post.js
@@ -4,6 +4,7 @@ import   htm              from "../web_modules/htm.js";
 const    html = htm.bind(createElement);
 
 import { htmlDecode }              from "../helpers/html-decode.js";
+import { prepareImagesForLoading } from "../helpers/html-images.js";
 import { normalizeURL }            from "../helpers/url.js";
 import { getBackgroundImage,
          getNormalizedCategories } from "../helpers/post.js";
@@ -27,7 +28,7 @@ function PostPage({ post, DOMParser }) {
 
       <div class="body"
         dangerouslySetInnerHTML=${
-          { __html: post.content.rendered }
+          { __html: prepareImagesForLoading({ html: post.content.rendered, DOMParser }) }
         }>
       </div>
 


### PR DESCRIPTION
1. Add height attribute if it’s missing from an image
2. Lazy load images